### PR TITLE
Use a 3-arg filter() for a Datastore query

### DIFF
--- a/cloud-nodejs/complete/books.js
+++ b/cloud-nodejs/complete/books.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
   }
 
   function getUserBooks(userId, callback) {
-    var query = dataset.createQuery(['Book']).filter('userId =', userId);
+    var query = dataset.createQuery(['Book']).filter('userId', '=', userId);
     dataset.runQuery(query, callback);
   }
 

--- a/cloud-nodejs/step-5-user-books/books.js
+++ b/cloud-nodejs/step-5-user-books/books.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
   }
 
   function getUserBooks(userId, callback) {
-    var query = dataset.createQuery(['Book']).filter('userId =', userId);
+    var query = dataset.createQuery(['Book']).filter('userId', '=', userId);
     dataset.runQuery(query, callback);
   }
 


### PR DESCRIPTION
The code for the solution for the Datastore query that is supposed to return
only a specific user's books fails to return any books. The problem is that
the comparison operator and property key were included in a single string.
Break the values out into separate strings so that the filter() method has
a property, comparison operator, and value as expected.

Closes #69.

Signed-off-by: Dan Scott <denials@gmail.com>